### PR TITLE
feat: Implement substitution-only simulator with JTT model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 indelsim/__pycache__/
 
 .venv
+.idea

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ pip install -e .
 
 ## Quick Start
 
-### Basic Usage
+### Indel Simulation - Basic Usage
 
 ```bash
 python indel_simulator.py \
@@ -100,7 +100,17 @@ python indel_simulator.py \
     --output_directory ./results
 ```
 
-### Advanced Usage
+### Substitution Simulation - Basic Usage
+
+```bash
+python substitution_simulator.py \
+    --substitution_rate 1.0 \
+    --tree_file tree.newick \
+    --original_sequence_length 1000 \
+    --output_directory ./substitution_results
+```
+
+### Indel Simulation - Advanced Usage
 
 ```bash
 python indel_simulator.py \
@@ -120,7 +130,25 @@ python indel_simulator.py \
     --verbose
 ```
 
+### Substitution Simulation - Advanced Usage
+
+```bash
+python substitution_simulator.py \
+    --substitution_rate 2.0 \
+    --algorithm matrix \
+    --tree_file tree.newick \
+    --original_sequence_length 500 \
+    --number_of_simulations 50 \
+    --output_type multiple_files \
+    --output_directory ./substitution_results \
+    --seed 123 \
+    --benchmark \
+    --verbose
+```
+
 ## Command Line Arguments
+
+## Indel Simulator Arguments
 
 ### Required Arguments
 
@@ -150,7 +178,35 @@ python indel_simulator.py \
 - `--verbose`: Enable verbose output
 - `--benchmark`: Run benchmarking and report performance statistics
 
+## Substitution Simulator Arguments
+
+### Required Arguments
+
+- `--substitution_rate FLOAT`: Substitution rate per site per unit time (default: 1.0)
+- `--tree_file PATH`: Path to Newick format phylogenetic tree file
+
+### Algorithm Selection
+
+- `--algorithm {gillespie,matrix}`: Substitution algorithm (default: gillespie)
+  - `gillespie`: Exact CTMC simulation using Gillespie algorithm
+  - `matrix`: Matrix exponentiation method for faster computation
+
+### Simulation Parameters
+
+- `--original_sequence_length INT`: Length of the root amino acid sequence (default: 1000)
+- `--number_of_simulations INT`: Number of independent simulation runs (default: 1)
+- `--seed INT`: Random seed for reproducibility (default: 42)
+
+### Output Options
+
+- `--output_type {drop_output,multiple_files,single_file}`: Output format (default: single_file)
+- `--output_directory PATH`: Directory to save simulation results (default: ./substitution_results)
+- `--verbose`: Enable verbose output
+- `--benchmark`: Run benchmarking and report performance statistics
+
 ## Algorithm Comparison
+
+### Indel Simulation Algorithms
 
 For a single branch:
 
@@ -165,9 +221,20 @@ Where:
 - n' = maximum sequence length during evolution
 - b = number of blocks (≤ min(k,n))
 
+### Substitution Simulation Algorithms
+
+| Method | Algorithm | Description |
+|--------|-----------|-------------|
+| **Gillespie** | Exact CTMC | Simulates exact substitution events using continuous-time Markov chain |
+| **Matrix** | Matrix Exponentiation | Uses pre-computed transition matrices for faster computation |
+
+**Performance recommendations:**
+- Use `gillespie` for exact results and moderate sequence lengths
+- Use `matrix` for large sequences or when speed is prioritized over exact timing
+
 ## Output Formats
 
-### FASTA Format
+### Indel Simulation FASTA Format
 ```
 # Simulation 1
 # Runtime: 0.123s
@@ -181,14 +248,41 @@ ATGCGATCGATCG--ATCGATCG
 ATGC--TCGATCGATCGATCG--
 ```
 
-The simulator outputs multiple sequence alignments in FASTA format with header comments containing simulation metadata.
+### Substitution Simulation FASTA Format
+```
+# Substitution Simulation 1
+# Runtime: 0.009s
+# Algorithm: gillespie
+# Substitution rate: 1.0
+# Seed: 42
+>A_sim1
+SHTFRKSSWIGFKSICLAAKAGVWFDIANFSVENIDNVCFHTFERSEAFNDASMFSILNRMILSKLPETHDGTC
+>B_sim1
+SRTFRVSSWIGYKSVCLASKPGVWSDILNFPVEGIDNVCFHSFERSAEFNDASMFSILNRMILSKLLEAHDGTC
+>C_sim1
+SHTFRVSSKIGYKSICLASKPGVWSDIQNSPVEGIDNICFHTFETRGEFGDASMFSIINRMVLSKLLEAHDGTC
+>D_sim1
+SYTFRVSARIGYKSICLASKPGVWADIASSPTEGIDNVCFHTFETSGDFTDSSMISILNRMILSKLLEAHDGTC
+```
+
+Both simulators output multiple sequence alignments in FASTA format with header comments containing simulation metadata. **Note:** Substitution simulation produces sequences of equal length (amino acids only), while indel simulation produces variable-length sequences with gaps.
 
 ## Performance Tips
 
+### Indel Simulation
 1. **For small tree branches (< 1.0) and insertion rate up to 0.1**: Use `--type list` for good performance
-1. **For large tree branches (> 1.0) and insertion rate higher than 0.05**: Use `--type tree` for best performance
+2. **For large tree branches (> 1.0) and insertion rate higher than 0.05**: Use `--type tree` for best performance
+
+### Substitution Simulation
+1. **For exact timing and moderate sequences (< 10,000 sites)**: Use `--algorithm gillespie`
+2. **For large sequences or high-throughput simulations**: Use `--algorithm matrix`
+3. **For very short branch lengths**: Matrix algorithm may be more efficient
+4. **For long branch lengths with many substitutions**: Gillespie provides exact event timing
+
+### General Tips
 1. **For benchmarking**: Use `--benchmark` flag to get detailed timing information
-1. **For reproducibility**: Always set `--seed` to a fixed value
+2. **For reproducibility**: Always set `--seed` to a fixed value
+3. **For batch processing**: Use `--number_of_simulations` for multiple runs with incremented seeds
 
 ## Tree File Format
 

--- a/indelsim/classes/jtt.py
+++ b/indelsim/classes/jtt.py
@@ -1,0 +1,464 @@
+"""
+Enhanced JTT (Jones-Taylor-Thornton) Substitution Model Implementation
+
+This module provides a robust, object-oriented implementation of the JTT model
+for calculating amino acid substitution probabilities over evolutionary time.
+
+# Simple usage
+model = JTTModel()
+P_t = model.transition_probability(1.0)  # Auto-computes model if needed
+
+# With custom configuration
+config = JTTConfig(ZERO_TOLERANCE=1e-10, CACHE_SIZE=256)
+model = JTTModel(config)
+
+# Validate model properties
+validation_results = model.validate_model_properties()
+all_passed = all(validation_results.values())
+
+"""
+
+import numpy as np
+from typing import Optional, Tuple, Dict, Any
+from dataclasses import dataclass
+from scipy.linalg import expm
+import warnings
+from functools import lru_cache
+
+# -------------------------------------------------------------------------- #
+# Global singleton helper                                                    #
+# -------------------------------------------------------------------------- #
+
+__all__ = ["JTTConfig", "JTTModel", "JTTModelError", "get_jtt_model"]
+
+# Cache a single computed model so multiple SubstitutionEvolver instances
+# don’t redo the expensive eigendecomposition.
+_GLOBAL_MODEL: "JTTModel | None" = None
+
+
+def get_jtt_model() -> "JTTModel":
+    """Return a globally shared, pre-computed JTTModel instance."""
+    global _GLOBAL_MODEL
+    if _GLOBAL_MODEL is None:
+        _GLOBAL_MODEL = JTTModel()
+        _GLOBAL_MODEL.compute_model()
+    return _GLOBAL_MODEL
+
+# -------------------------------------------------------------------------- #
+
+@dataclass(frozen=True)
+class JTTConfig:
+    """Configuration parameters for the JTT model."""
+    
+    # Number of amino acids
+    NUM_AMINO_ACIDS: int = 20
+    
+    # Numerical tolerances
+    ZERO_TOLERANCE: float = 1e-8
+    BALANCE_TOLERANCE: float = 1e-8
+    RECONSTRUCTION_TOLERANCE: float = 1e-10
+    
+    # Time limits for calculations
+    MIN_TIME: float = 1e-10
+    MAX_TIME: float = 1000.0
+    
+    # Cache size for transition matrices
+    CACHE_SIZE: int = 128
+
+
+class JTTModelError(Exception):
+    """Base exception for JTT model errors."""
+    pass
+
+
+class JTTModel:
+    """
+    Jones-Taylor-Thornton substitution model for amino acid evolution.
+    
+    This class encapsulates the JTT model, providing methods to compute
+    transition probabilities and validate model properties.
+
+    # TODO: share model across simulations. 
+    """
+    
+    def __init__(self, config: Optional[JTTConfig] = None):
+        """
+        Initialize the JTT model.
+        
+        Args:
+            config: Configuration parameters (uses defaults if None)
+        """
+        self.config = config or JTTConfig()
+        self._is_computed = False
+        self._cache = {}
+        
+        # Model components (initialized when computed)
+        self._Q: Optional[np.ndarray] = None
+        self._eigenvalues: Optional[np.ndarray] = None
+        self._Y: Optional[np.ndarray] = None
+        self._Y_inv: Optional[np.ndarray] = None
+        self._pi: Optional[np.ndarray] = None
+        self._v_matrix: Optional[np.ndarray] = None
+        
+        # Initialize model data
+        self._initialize_data()
+    
+    def _initialize_data(self) -> None:
+        """Initialize the empirical data for the JTT model."""
+        # Amino acid equilibrium frequencies
+        self._pi_data = np.array([
+            0.076748, 0.051691, 0.042645, 0.051544, 0.019803,
+            0.040752, 0.061830, 0.073152, 0.022944, 0.053761,
+            0.091904, 0.058676, 0.023826, 0.040126, 0.050901,
+            0.068765, 0.058565, 0.014261, 0.032102, 0.066005
+        ])
+        
+        # Empirical substitution counts (upper triangle)
+        self._tri_counts = np.array([
+            58, 54, 45, 81, 16, 528, 56, 113, 34, 10, 57, 310, 86, 49, 9,
+            105, 29, 58, 767, 5, 323, 179, 137, 81, 130, 59, 26, 119, 27,
+            328, 391, 112, 69, 597, 26, 23, 36, 22, 47, 11, 17, 9, 12, 6,
+            16, 30, 38, 12, 7, 23, 72, 9, 6, 56, 229, 35, 646, 263, 26,
+            7, 292, 181, 27, 45, 21, 14, 54, 44, 30, 15, 31, 43, 18, 14,
+            33, 479, 388, 65, 15, 5, 10, 4, 78, 4, 5, 5, 40, 89, 248, 4,
+            43, 194, 74, 15, 15, 14, 164, 18, 24, 115, 10, 102, 21, 16,
+            17, 378, 101, 503, 59, 223, 53, 30, 201, 73, 40, 59, 47, 29,
+            92, 285, 475, 64, 232, 38, 42, 51, 32, 33, 46, 245, 25, 103,
+            226, 12, 118, 477, 9, 126, 8, 4, 115, 18, 10, 55, 8, 9, 52,
+            10, 24, 53, 6, 35, 12, 11, 20, 70, 46, 209, 24, 7, 8, 573,
+            32, 24, 8, 18, 536, 10, 63, 21, 71, 298, 17, 16, 31, 62, 20,
+            45, 47, 11, 961, 180, 14, 323, 62, 23, 38, 112, 25, 16
+        ], dtype=float)
+        
+        # Validate data integrity
+        self._validate_data()
+    
+    def _validate_data(self) -> None:
+        """Validate the empirical data."""
+        n = self.config.NUM_AMINO_ACIDS
+        expected_tri_count = n * (n - 1) // 2
+        
+        if len(self._pi_data) != n:
+            raise JTTModelError(f"Expected {n} amino acid frequencies, got {len(self._pi_data)}")
+        
+        if len(self._tri_counts) != expected_tri_count:
+            raise JTTModelError(f"Expected {expected_tri_count} substitution counts, got {len(self._tri_counts)}")
+        
+        if not np.isclose(self._pi_data.sum(), 1.0):
+            raise JTTModelError(f"Amino acid frequencies sum to {self._pi_data.sum():.6f}, expected 1.0")
+        
+        if np.any(self._pi_data <= 0):
+            raise JTTModelError("All amino acid frequencies must be positive")
+        
+        if np.any(self._tri_counts < 0):
+            raise JTTModelError("All substitution counts must be non-negative")
+    
+    def compute_model(self) -> None:
+        """
+        Compute the JTT model components.
+        
+        This method builds the rate matrix Q, performs eigendecomposition,
+        and validates the resulting model.
+        """
+        if self._is_computed:
+            return
+        
+        try:
+            # Build the symmetric substitution matrix S
+            S = self._build_substitution_matrix()
+            
+            # Construct the rate matrix Q
+            Q = self._build_rate_matrix(S)
+            
+            # Scale Q to evolutionary time units
+            Q_scaled = self._scale_rate_matrix(Q)
+            
+            # Perform eigendecomposition
+            eigenvalues, Y, Y_inv, v_matrix = self._eigendecomposition(Q_scaled)
+            
+            # Validate the decomposition
+            self._validate_decomposition(Q_scaled, eigenvalues, Y, Y_inv)
+            
+            # Store results
+            self._Q = Q_scaled
+            self._eigenvalues = eigenvalues
+            self._Y = Y
+            self._Y_inv = Y_inv
+            self._pi = self._pi_data.copy()
+            self._v_matrix = v_matrix
+            
+            self._is_computed = True
+            
+        except Exception as e:
+            raise JTTModelError(f"Failed to compute JTT model: {str(e)}") from e
+    
+    def _build_substitution_matrix(self) -> np.ndarray:
+        """Build the symmetric substitution matrix S from empirical counts."""
+        n = self.config.NUM_AMINO_ACIDS
+        S = np.zeros((n, n))
+        
+        k = 0
+        for i in range(n):
+            for j in range(i):
+                S[i, j] = S[j, i] = self._tri_counts[k]
+                k += 1
+        
+        return S
+    
+    def _build_rate_matrix(self, S: np.ndarray) -> np.ndarray:
+        """Build the rate matrix Q from the substitution matrix S."""
+        # Q_ij = S_ij * π_j for i ≠ j
+        Q = S * self._pi_data[np.newaxis, :]
+        
+        # Set diagonal to zero initially
+        np.fill_diagonal(Q, 0.0)
+        
+        # Set diagonal elements to ensure row sums are zero
+        Q -= np.diag(Q.sum(axis=1))
+        
+        return Q
+    
+    def _scale_rate_matrix(self, Q: np.ndarray) -> np.ndarray:
+        """Scale the rate matrix Q to evolutionary time units."""
+        # Calculate the average substitution rate
+        rate = -(self._pi_data * np.diag(Q)).sum()
+        
+        if rate <= 0:
+            raise JTTModelError(f"Invalid substitution rate: {rate}")
+        
+        # Scale Q so that the average rate is 1.0
+        Q_scaled = Q / rate
+        
+        return Q_scaled
+    
+    def _eigendecomposition(self, Q: np.ndarray) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        """Perform eigendecomposition of the rate matrix Q."""
+        # Use symmetrization for numerical stability
+        sqrt_pi = np.sqrt(self._pi_data)
+        
+        # Avoid division by very small numbers
+        min_sqrt_pi = np.min(sqrt_pi)
+        if min_sqrt_pi < 1e-10:
+            warnings.warn(f"Very small amino acid frequency detected: {min_sqrt_pi**2:.2e}")
+        
+        # Build transformation matrices
+        T = np.diag(sqrt_pi)
+        T_inv = np.diag(1.0 / sqrt_pi)
+        
+        # Symmetrize: M = T * Q * T^(-1)
+        M = T @ Q @ T_inv
+        
+        # Eigendecomposition of symmetric matrix
+        eigenvalues, v_matrix = np.linalg.eigh(M)
+        
+        # Sort eigenvalues and eigenvectors in descending order
+        idx = np.argsort(eigenvalues)[::-1]
+        eigenvalues = eigenvalues[idx]
+        v_matrix = v_matrix[:, idx]
+        
+        # Transform back to original space
+        Y = T_inv @ v_matrix
+        Y_inv = v_matrix.T @ T
+        
+        return eigenvalues, Y, Y_inv, v_matrix
+    
+    def _validate_decomposition(self, Q: np.ndarray, eigenvalues: np.ndarray, Y: np.ndarray, Y_inv: np.ndarray) -> None:
+        """Validate the eigendecomposition results."""
+        # Check reconstruction
+        lambda_matrix = np.diag(eigenvalues)
+        Q_reconstructed = Y @ lambda_matrix @ Y_inv
+        
+        if not np.allclose(Q, Q_reconstructed, atol=self.config.RECONSTRUCTION_TOLERANCE):
+            raise JTTModelError("Eigendecomposition reconstruction failed")
+        
+        # Check eigenvalue structure
+        zero_evals = np.abs(eigenvalues) < self.config.ZERO_TOLERANCE
+        neg_evals = eigenvalues < -self.config.ZERO_TOLERANCE
+        
+        if np.sum(zero_evals) != 1:
+            raise JTTModelError(f"Expected 1 zero eigenvalue, found {np.sum(zero_evals)}")
+        
+        if np.sum(neg_evals) != self.config.NUM_AMINO_ACIDS - 1:
+            raise JTTModelError(f"Expected {self.config.NUM_AMINO_ACIDS - 1} negative eigenvalues, found {np.sum(neg_evals)}")
+    
+
+    @lru_cache(maxsize=128)
+    def _transition_probability_cached(self, t_quantized: float) -> np.ndarray:
+        """Internal cached method for transition probability calculation."""
+        # Calculate P(t) = Y * exp(Λt) * Y^(-1)
+        exp_lambda_t = np.diag(np.exp(self._eigenvalues * t_quantized))
+        P_t = self._Y @ exp_lambda_t @ self._Y_inv
+        
+        # Validate result
+        self._validate_transition_matrix(P_t)
+        
+        return P_t
+    
+    def transition_probability(self, t: float) -> np.ndarray:
+        """
+        Calculate the transition probability matrix P(t) = exp(Qt).
+        
+        Args:
+            t: Evolutionary time (must be positive)
+            
+        Returns:
+            Transition probability matrix P(t)
+            
+        Raises:
+            JTTModelError: If time is invalid or model not computed
+        """
+        if not self._is_computed:
+            self.compute_model()
+        
+        # Validate time parameter
+        if not isinstance(t, (int, float)) or np.isnan(t) or np.isinf(t):
+            raise JTTModelError(f"Invalid time value: {t}")
+        
+        if t < self.config.MIN_TIME:
+            raise JTTModelError(f"Time {t} is too small (minimum: {self.config.MIN_TIME})")
+        
+        if t > self.config.MAX_TIME:
+            warnings.warn(f"Large time value {t} may cause numerical issues")
+        
+        # Quantize time to 10 decimal places for cache efficiency
+        t_quantized = round(t, 10)
+        
+        return self._transition_probability_cached(t_quantized)
+    
+    def _validate_transition_matrix(self, P: np.ndarray) -> None:
+        """Validate the transition probability matrix."""
+        # Check row sums
+        row_sums = P.sum(axis=1)
+        if not np.allclose(row_sums, 1.0, atol=self.config.ZERO_TOLERANCE):
+            raise JTTModelError(f"Transition matrix rows don't sum to 1.0: {row_sums}")
+        
+        # Check bounds
+        if np.any(P < -self.config.ZERO_TOLERANCE) or np.any(P > 1.0 + self.config.ZERO_TOLERANCE):
+            raise JTTModelError("Transition matrix contains invalid probabilities")
+    
+    def validate_model_properties(self) -> Dict[str, bool]:
+        """
+        Validate all mathematical properties of the JTT model.
+        
+        Returns:
+            Dictionary of validation results
+        """
+        if not self._is_computed:
+            self.compute_model()
+        
+        results = {}
+        
+        # Test 1: Q row sums should be zero
+        results['q_row_sums'] = np.allclose(self._Q.sum(axis=1), 0, atol=self.config.ZERO_TOLERANCE)
+        
+        # Test 2: Detailed balance
+        left = self._pi[:, None] * self._Q
+        right = left.T
+        results['detailed_balance'] = np.allclose(left, right, atol=self.config.BALANCE_TOLERANCE)
+        
+        # Test 3: Eigenvalue structure
+        zero_evals = np.abs(self._eigenvalues) < self.config.ZERO_TOLERANCE
+        neg_evals = self._eigenvalues < -self.config.ZERO_TOLERANCE
+        results['eigenvalue_structure'] = (np.sum(zero_evals) == 1 and np.sum(neg_evals) == 19)
+        
+        # Test 4: Eigenvector orthogonality
+        results['orthogonality'] = np.allclose(self._v_matrix.T @ self._v_matrix, np.eye(20), atol=self.config.ZERO_TOLERANCE)
+        
+        # Test 5: Stationarity
+        P_test = self.transition_probability(1.0)
+        results['stationarity'] = np.allclose(self._pi @ P_test, self._pi, atol=self.config.ZERO_TOLERANCE)
+        
+        # Test 6: Comparison with matrix exponential
+        P_direct = expm(self._Q * 1.0)
+        results['expm_comparison'] = np.allclose(P_test, P_direct, atol=self.config.ZERO_TOLERANCE)
+        
+        return results
+    
+    @property
+    def rate_matrix(self) -> np.ndarray:
+        """Get the rate matrix Q."""
+        if not self._is_computed:
+            self.compute_model()
+        return self._Q.copy()
+    
+    @property
+    def equilibrium_frequencies(self) -> np.ndarray:
+        """Get the normalised equilibrium amino acid frequencies."""
+        return (self._pi_data / self._pi_data.sum()).copy()
+    
+    @property
+    def eigenvalues(self) -> np.ndarray:
+        """Get the eigenvalues of the rate matrix."""
+        if not self._is_computed:
+            self.compute_model()
+        return self._eigenvalues.copy()
+    
+    def __repr__(self) -> str:
+        """String representation of the JTT model."""
+        status = "computed" if self._is_computed else "not computed"
+        return f"JTTModel(status={status}, amino_acids={self.config.NUM_AMINO_ACIDS})"
+
+
+# Convenience functions for backward compatibility
+def compute_jtt_model() -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """
+    Legacy function for backward compatibility.
+    
+    Returns:
+        Tuple of (Q, eigenvalues, Y, Y_inv, pi)
+    """
+    model = JTTModel()
+    model.compute_model()
+    return (model._Q, model._eigenvalues, model._Y, model._Y_inv, model._pi)
+
+
+def calculate_p_t(t: float, eigenvalues: np.ndarray, Y: np.ndarray, Y_inv: np.ndarray) -> np.ndarray:
+    """
+    Legacy function for backward compatibility.
+    
+    Args:
+        t: Evolutionary time
+        eigenvalues: Eigenvalues of the rate matrix
+        Y: Eigenvector matrix
+        Y_inv: Inverse eigenvector matrix
+        
+    Returns:
+        Transition probability matrix P(t)
+    """
+    exp_lambda_t = np.diag(np.exp(eigenvalues * t))
+    P_t = Y @ exp_lambda_t @ Y_inv
+    return P_t
+
+
+# Example usage and testing
+if __name__ == "__main__":
+    # Create and compute the JTT model
+    model = JTTModel()
+    print(f"JTT Model: {model}")
+    
+    # Compute model components
+    model.compute_model()
+    print(f"JTT Model: {model}")
+    
+    # Calculate transition probabilities
+    t_values = [0.1, 0.5, 1.0, 2.0, 5.0]
+    
+    print("\n--- Transition Probabilities ---")
+    for t in t_values:
+        P_t = model.transition_probability(t)
+        print(f"t={t}: P(t) shape={P_t.shape}, min={P_t.min():.6f}, max={P_t.max():.6f}")
+    
+    # Validate model properties
+    print("\n--- Model Validation ---")
+    validation_results = model.validate_model_properties()
+    for test_name, passed in validation_results.items():
+        status = "PASS" if passed else "FAIL"
+        print(f"{test_name}: {status}")
+    
+    # Display some model properties
+    print(f"\n--- Model Properties ---")
+    print(f"Equilibrium frequencies sum: {model.equilibrium_frequencies.sum():.6f}")
+    print(f"Eigenvalues range: [{model.eigenvalues.min():.6f}, {model.eigenvalues.max():.6f}]")
+    print(f"Rate matrix trace: {np.trace(model.rate_matrix):.6f}")
+
+

--- a/indelsim/classes/msa.py
+++ b/indelsim/classes/msa.py
@@ -4,7 +4,7 @@ from indelsim.classes.sequence import Sequence
 
 class Msa:
     _aligned_sequences: dict[int, str]
-    _substitutions: list[str]
+    _substitutions: list[str] # dict[int, list[int]]
     _msa_length: int
     _number_of_sequences: int
     _sequences_to_save: list[int]

--- a/indelsim/classes/sim_config.py
+++ b/indelsim/classes/sim_config.py
@@ -7,8 +7,15 @@ class SimConfiguration:
     deletion_extra_edge_length: int
     random_seed: int
 
+    enable_substitutions: bool
+    substitution_rate: float = 1.0
+    substitution_model: str = "jtt"
+    substitution_algorithm: str = "gillespie"
+
     def __init__(self, original_sequence_length: int, indel_length_alpha: float, indel_truncated_length: int,
-                 rate_ins: float, rate_del: float, deletion_extra_edge_length: int, seed: int):
+                 rate_ins: float, rate_del: float, deletion_extra_edge_length: int, seed: int,
+                 enable_substitutions: bool = False, substitution_model: str = "jtt", 
+                 substitution_algorithm = "gillespie", substitution_rate: float = 1.0):
 
         self.rate_ins = rate_ins
         self.rate_del = rate_del
@@ -17,3 +24,8 @@ class SimConfiguration:
         self.indel_truncated_length = indel_truncated_length
         self.deletion_extra_edge_length = deletion_extra_edge_length
         self.random_seed = seed
+
+        self.substitution_rate = substitution_rate
+        self.enable_substitutions = enable_substitutions
+        self.substitution_model = substitution_model
+        self.substitution_algorithm = substitution_algorithm

--- a/indelsim/classes/substitution.py
+++ b/indelsim/classes/substitution.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""
+Implements both a Gillespie-style CTMC sampler (`evolve_branch_substitutions_gillespie`)
+and a matrix-exponential sampler (`evolve_branch_substitutions_jtt`)
+under the JTT model.
+"""
+
+from __future__ import annotations
+from typing import List, Optional
+
+
+import numpy as np
+from indelsim.classes.jtt import get_jtt_model
+from indelsim.enums import AminoAcid, amino_acid_to_index, index_to_amino_acid
+
+# Constants for validation
+MAX_BRANCH_LENGTH = 1000.0
+MIN_SUBSTITUTION_RATE = 1e-10
+
+class SubstitutionEvolver:
+    """
+    Evolves amino-acid sequences along a branch under the JTT model.
+    
+    Parameters
+    ----------
+    substitution_rate
+        Scalar multiplier applied to JTT's normalised rate matrix.
+    seed
+        If given, a NumPy PCG64 RNG is created with this seed;
+        otherwise a fresh unpredictable RNG is used.
+    """
+    
+    def __init__(self, substitution_rate: float = 1.0, seed: Optional[int] = None):
+        if substitution_rate < MIN_SUBSTITUTION_RATE:
+            raise ValueError(f"substitution_rate must be >= {MIN_SUBSTITUTION_RATE}")
+            
+        self.substitution_rate = float(substitution_rate)
+        self.jtt_model = get_jtt_model()
+
+        if seed is not None:
+            self.rng = np.random.default_rng(seed)
+        else:
+            self.rng = np.random.default_rng()
+    
+    def evolve_branch_substitutions_gillespie(
+        self,
+        sequence: List[int],
+        branch_length: float
+    ) -> List[int]:
+        """
+        Simulate substitutions along a branch with the Gillespie algorithm.
+
+        Parameters
+        ----------
+        sequence
+            List of length L with integer amino-acid codes 0-19.
+        branch_length
+            Time units for this branch (must be non-negative).
+
+        Returns
+        -------
+        list[int]
+            New list (length L) after substitutions.
+        """
+        self._validate_inputs(sequence, branch_length)
+
+        Q: np.ndarray = self.jtt_model.rate_matrix * self.substitution_rate
+        L: int = len(sequence)
+        seq: list[int] = sequence.copy()
+
+        # Pre-compute exit rates λ_i = −Q_ii
+        exit_rates = np.asarray([-Q[aa, aa] for aa in seq], dtype=float)
+        total_rate: float = exit_rates.sum()
+
+        t: float = 0.0
+        rng = self.rng
+
+        while t < branch_length and total_rate > 0.0:
+            # 1. waiting time to next event
+            t += rng.exponential(1.0 / total_rate)
+            if t >= branch_length:
+                break
+
+            # 2. choose site, proportional to exit rate
+            site = rng.choice(L, p=exit_rates / total_rate)
+
+            old_aa = seq[site]
+
+            # 3. draw target residue conditional on leaving old_aa
+            probs = Q[old_aa].copy()
+            probs[old_aa] = 0.0
+            probs /= exit_rates[site]          # normalise row
+            new_aa = rng.choice(20, p=probs)
+
+            # 4. update sequence and rates
+            seq[site] = new_aa
+            new_exit = -Q[new_aa, new_aa]
+            total_rate += new_exit - exit_rates[site]
+            exit_rates[site] = new_exit
+
+        return seq
+    
+    def evolve_branch_substitutions_jtt(
+        self,
+        sequence: List[int],
+        branch_length: float
+    ) -> List[int]:
+        """
+        Simulate substitutions via pre-computed transition matrix exp(Q t).
+
+        Faster for long sequences / many sites, but incurs one matrix
+        exponential per distinct branch length.
+
+        Returns a fresh list with evolved residues.
+        """
+        self._validate_inputs(sequence, branch_length)
+
+        eff_time = branch_length * self.substitution_rate
+        P_t: np.ndarray = self.jtt_model.transition_probability(eff_time)
+
+        probs = P_t[np.asarray(sequence, dtype=np.uint8)]          # shape (L, 20)
+        cumprob = np.cumsum(probs, axis=1)
+        u = self.rng.random((len(sequence), 1))
+        evolved = np.argmax(u < cumprob, axis=1).astype(np.uint8)
+        return evolved.tolist()
+    
+    def evolve_sequence_chars(self, sequence_chars: List[str], branch_length: float) -> List[str]:
+        """Same as gillespie method, but with ACDE.. chars"""
+        indices = [amino_acid_to_index(aa) for aa in sequence_chars]
+        evolved_indices = self.evolve_branch_substitutions_gillespie(indices, branch_length)
+        return [index_to_amino_acid(idx) for idx in evolved_indices]
+
+    def _validate_inputs(self, sequence: List[int], branch_length: float) -> None:
+        if branch_length < 0.0:
+            raise ValueError("branch_length must be non-negative")
+        if branch_length > MAX_BRANCH_LENGTH:
+            raise ValueError(f"branch_length {branch_length} exceeds maximum {MAX_BRANCH_LENGTH}")
+        if not sequence:
+            raise ValueError("sequence cannot be empty")

--- a/indelsim/enums.py
+++ b/indelsim/enums.py
@@ -1,4 +1,4 @@
-from enum import Enum
+from enum import Enum, IntEnum
 
 
 class SimulationTypes(Enum):
@@ -25,3 +25,40 @@ class EventSubTypes(Enum):
     OUT_OF_SEQUENCE = 14
 
 
+class AminoAcid(IntEnum):
+    A = 0   # Alanine
+    R = 1   # Arginine
+    N = 2   # Asparagine
+    D = 3   # Aspartic acid
+    C = 4   # Cysteine
+    Q = 5   # Glutamine
+    E = 6   # Glutamic acid
+    G = 7   # Glycine
+    H = 8   # Histidine
+    I = 9   # Isoleucine
+    L = 10  # Leucine
+    K = 11  # Lysine
+    M = 12  # Methionine
+    F = 13  # Phenylalanine
+    P = 14  # Proline
+    S = 15  # Serine
+    T = 16  # Threonine
+    W = 17  # Tryptophan
+    Y = 18  # Tyrosine
+    V = 19  # Valine
+
+def amino_acid_to_index(aa: str) -> int:
+    """Convert amino acid character to index (0-19)."""
+    try:
+        return AminoAcid[aa].value
+    except KeyError:
+        raise ValueError(f"Invalid amino acid: {aa}")
+
+def index_to_amino_acid(index: int) -> str:
+    """Convert index (0-19) to amino acid character."""
+    try:
+        return AminoAcid(index).name
+    except ValueError:
+        raise ValueError(f"Invalid amino acid index: {index}")
+    
+PROTEIN_ALPHABET = [aa.name for aa in AminoAcid]

--- a/indelsim/substitution_simulator.py
+++ b/indelsim/substitution_simulator.py
@@ -1,0 +1,399 @@
+# CLI tool to substitutions simulator
+
+#!/usr/bin/env python3
+"""
+CLI tool to simulate substitutions in a sequence.
+
+"""
+
+import argparse
+import sys
+import os
+import pathlib
+from typing import List, Dict, Any
+import time
+from datetime import datetime
+import numpy as np
+
+from indelsim.classes.simulation import Simulation
+from indelsim.classes.sim_config import SimConfiguration
+from indelsim.classes.substitution import SubstitutionEvolver
+from indelsim.classes.jtt import get_jtt_model
+from indelsim.enums import index_to_amino_acid
+from ete3 import Tree
+
+
+class SubstitutionSimulatorCLI:
+    """Command-line interface for the substitution simulator."""
+    
+    def __init__(self):
+        self.parser = self._create_parser()
+    
+    def _create_parser(self) -> argparse.ArgumentParser:
+        """Create and configure the argument parser."""
+        parser = argparse.ArgumentParser(
+            description="Simulate amino acid substitutions along phylogenetic trees",
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            epilog="""
+Examples:
+  # Basic simulation with Gillespie algorithm
+  python substitution_simulator.py --substitution_rate 1.0 --tree_file tree.newick 
+                                    --output_directory ./results
+  
+  # Matrix exponentiation method
+  python substitution_simulator.py --substitution_rate 0.5 --algorithm matrix
+                                    --tree_file tree.newick --number_of_simulations 10
+            """
+        )
+        
+        parser.add_argument(
+            "--substitution_rate",
+            type=float,
+            default=1.0,
+            help="Substitution rate per site per unit time"
+        )
+        
+        parser.add_argument(
+            "--tree_file",
+            type=str,
+            required=True,
+            help="Path to Newick format phylogenetic tree file"
+        )
+
+        # TODO: add model
+        # parser.add_argument(
+        #     "--substitution_model",
+        #     type=str,
+        # )
+        
+        # Algorithm selection
+        parser.add_argument(
+            "--algorithm",
+            choices=["gillespie", "matrix"],
+            default="gillespie",
+            help="Substitution algorithm: gillespie (exact CTMC) or matrix (exponentiation)"
+        )
+        
+        # Simulation parameters
+        parser.add_argument(
+            "--original_sequence_length",
+            type=int,
+            default=1000,
+            help="Length of the root sequence (default: 1000)"
+        )
+        
+        parser.add_argument(
+            "--number_of_simulations",
+            type=int,
+            default=1,
+            help="Number of independent simulation runs (default: 1)"
+        )
+        
+        parser.add_argument(
+            "--seed",
+            type=int,
+            default=42,
+            help="Random seed for reproducibility (default: 42)"
+        )
+        
+        # Output options
+        parser.add_argument(
+            "--output_type",
+            choices=["drop_output", "multiple_files", "single_file"],
+            default="single_file",
+            help="Output format: drop_output (no files), multiple_files (one fasta per sim), single_file (combined fastas)"
+        )
+        
+        parser.add_argument(
+            "--output_directory",
+            type=str,
+            default="./substitution_results",
+            help="Directory to save simulation results (default: ./substitution_results)"
+        )
+        
+        parser.add_argument(
+            "--verbose",
+            action="store_true",
+            help="Enable verbose output"
+        )
+        
+        parser.add_argument(
+            "--benchmark",
+            action="store_true",
+            help="Run benchmarking and report performance statistics"
+        )
+        
+        return parser
+    
+    def _validate_args(self, args: argparse.Namespace) -> None:
+        """Validate command-line arguments."""
+        # Check if tree file exists
+        if not os.path.exists(args.tree_file):
+            raise FileNotFoundError(f"Tree file not found: {args.tree_file}")
+        
+        # Validate substitution rate
+        if args.substitution_rate < 0:
+            raise ValueError("Substitution rate must be non-negative")
+        
+        # Validate sequence length
+        if args.original_sequence_length <= 0:
+            raise ValueError("Original sequence length must be positive")
+        
+        # Validate number of simulations
+        if args.number_of_simulations <= 0:
+            raise ValueError("Number of simulations must be positive")
+    
+    def _create_sim_config(self, args: argparse.Namespace) -> SimConfiguration:
+        """Create simulation configuration from arguments."""
+        return SimConfiguration(
+            original_sequence_length=args.original_sequence_length,
+            indel_length_alpha=2.0,  # Default values for indel params (not used)
+            indel_truncated_length=50,
+            deletion_extra_edge_length=0,
+            rate_ins=0.0,  # No indels in substitution-only simulation
+            rate_del=0.0,
+            seed=args.seed,
+            substitution_rate=args.substitution_rate,
+            enable_substitutions=True,
+            substitution_algorithm=args.algorithm
+        )
+    
+    def _generate_root_sequence(self, length: int, seed: int) -> List[int]:
+        """Generate random amino acid sequence using JTT equilibrium frequencies."""
+        jtt_model = get_jtt_model()
+        equilibrium_freqs = jtt_model.equilibrium_frequencies
+        
+        # Create RNG with the provided seed
+        rng = np.random.default_rng(seed)
+        
+        # Sample amino acids according to equilibrium frequencies
+        root_sequence = rng.choice(20, size=length, p=equilibrium_freqs)
+        return root_sequence.tolist()
+    
+    def _simulate_substitutions(self, args: argparse.Namespace, seed: int) -> Dict[str, List[str]]:
+        """Run the complete substitution simulation workflow."""
+        # 1. Generate root sequence
+        root_sequence = self._generate_root_sequence(args.original_sequence_length, seed)
+        
+        # 2. Parse phylogenetic tree
+        tree = Tree(args.tree_file)
+        
+        # 3. Create substitution evolver
+        evolver = SubstitutionEvolver(
+            substitution_rate=args.substitution_rate,
+            seed=seed
+        )
+        
+        # 4. Evolve sequences along tree
+        sequences = {}
+        
+        # Add root sequence (if tree has a name for root)
+        if hasattr(tree, 'name') and tree.name:
+            sequences[tree.name] = [index_to_amino_acid(aa) for aa in root_sequence]
+        
+        # Traverse tree and evolve sequences
+        for node in tree.traverse("preorder"):
+            if node.is_root():
+                # Set root sequence
+                node.sequence = root_sequence
+            else:
+                # Evolve from parent
+                parent_sequence = node.up.sequence
+                branch_length = node.dist
+                
+                # Choose evolution algorithm
+                if args.algorithm == "gillespie":
+                    evolved_sequence = evolver.evolve_branch_substitutions_gillespie(
+                        parent_sequence, branch_length
+                    )
+                else:  # matrix algorithm
+                    evolved_sequence = evolver.evolve_branch_substitutions_jtt(
+                        parent_sequence, branch_length
+                    )
+                
+                node.sequence = evolved_sequence
+                
+                # If this is a leaf node, store the sequence
+                if node.is_leaf():
+                    node_name = node.name if node.name else f"leaf_{id(node)}"
+                    sequences[node_name] = [index_to_amino_acid(aa) for aa in evolved_sequence]
+        
+        # Verify all sequences have equal length
+        self._verify_sequence_lengths(sequences, args.original_sequence_length)
+        
+        return sequences
+    
+    def _verify_sequence_lengths(self, sequences: Dict[str, List[str]], expected_length: int) -> None:
+        """Verify that all sequences have the expected length."""
+        for species_name, sequence in sequences.items():
+            actual_length = len(sequence)
+            if actual_length != expected_length:
+                raise ValueError(
+                    f"Sequence length mismatch for {species_name}: "
+                    f"expected {expected_length}, got {actual_length}. "
+                    f"All sequences should have equal length in substitution-only simulation."
+                )
+    
+    def _run_single_simulation(self, args: argparse.Namespace, sim_num: int) -> Dict[str, Any]:
+        """Run a single simulation and return results."""
+        if args.verbose:
+            print(f"Running substitution simulation {sim_num + 1}/{args.number_of_simulations}...")
+        
+        # Create configuration with incremented seed for each simulation
+        config = self._create_sim_config(args)
+        config.random_seed = args.seed + sim_num
+        
+        start_time = time.perf_counter()
+        
+        # Run substitution simulation
+        msa = self._simulate_substitutions(args, config.random_seed)
+        
+        end_time = time.perf_counter()
+        runtime = end_time - start_time
+
+        # Collect results
+        results = {
+            "simulation_number": sim_num + 1,
+            "runtime_seconds": runtime,
+            "algorithm": args.algorithm,
+            "config": {
+                "substitution_rate": args.substitution_rate,
+                "original_sequence_length": args.original_sequence_length,
+                "seed": config.random_seed
+            },
+            "msa": msa
+        }
+        
+        if args.verbose:
+            print(f"  Completed in {runtime:.3f} seconds")
+        
+        return results
+    
+    def _save_results(self, results: List[Dict[str, Any]], args: argparse.Namespace) -> None:
+        """Save simulation results to files."""
+        if args.output_type == "drop_output":
+            return
+        
+        # Create output directory
+        output_dir = pathlib.Path(args.output_directory)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        
+        if args.output_type == "multiple_files":
+            self._save_multiple_files(results, args, output_dir)
+        elif args.output_type == "single_file":
+            self._save_single_file(results, args, output_dir)
+    
+    def _save_multiple_files(self, results: List[Dict[str, Any]], args: argparse.Namespace, output_dir: pathlib.Path) -> None:
+        """Save each simulation to a separate file."""
+        for result in results:
+            sim_num = result["simulation_number"]
+            
+            filename = output_dir / f"substitution_sim_{sim_num:04d}.fasta"
+            self._write_fasta(result["msa"], filename)
+            
+            if args.verbose:
+                print(f"Saved simulation {sim_num} to {filename}")
+    
+    def _save_single_file(self, results: List[Dict[str, Any]], args: argparse.Namespace, output_dir: pathlib.Path) -> None:
+        """Save all simulations to a single file."""
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        
+        filename = output_dir / f"substitution_simulations_{timestamp}.fasta"
+        with open(filename, 'w') as f:
+            for result in results:
+                f.write(f"# Substitution Simulation {result['simulation_number']}\n")
+                f.write(f"# Runtime: {result['runtime_seconds']:.3f}s\n")
+                f.write(f"# Algorithm: {result['algorithm']}\n")
+                f.write(f"# Substitution rate: {result['config']['substitution_rate']}\n")
+                f.write(f"# Seed: {result['config']['seed']}\n")
+                
+                # Write MSA sequences
+                msa = result["msa"]
+                for species_name, sequence in msa.items():
+                    f.write(f">{species_name}_sim{result['simulation_number']}\n")
+                    f.write("".join(sequence))
+                    f.write("\n")
+                f.write("\n")
+        
+        if args.verbose:
+            print(f"Saved {len(results)} simulations to {filename}")
+    
+    def _write_fasta(self, msa: Dict[str, List[str]], filename: pathlib.Path) -> None:
+        """Write MSA in FASTA format."""
+        with open(filename, 'w') as f:
+            for species_name, sequence in msa.items():
+                f.write(f">{species_name}\n")
+                f.write("".join(sequence))
+                f.write("\n")
+    
+    def _print_benchmark_results(self, results: List[Dict[str, Any]], args: argparse.Namespace) -> None:
+        """Print benchmarking statistics."""
+        runtimes = [r["runtime_seconds"] for r in results]
+        
+        print("\n" + "="*50)
+        print("SUBSTITUTION SIMULATION BENCHMARK RESULTS")
+        print("="*50)
+        print(f"Algorithm: {args.algorithm}")
+        print(f"Number of simulations: {len(results)}")
+        print(f"Original sequence length: {args.original_sequence_length}")
+        print(f"Substitution rate: {args.substitution_rate}")
+        print("-"*50)
+        print(f"Total runtime: {sum(runtimes):.3f}s")
+        print(f"Average runtime: {sum(runtimes)/len(runtimes):.3f}s")
+        print(f"Min runtime: {min(runtimes):.3f}s")
+        print(f"Max runtime: {max(runtimes):.3f}s")
+        if len(runtimes) > 1:
+            import statistics
+            print(f"Std deviation: {statistics.stdev(runtimes):.3f}s")
+        print("="*50)
+    
+    def run(self) -> None:
+        """Main entry point for the CLI."""
+        try:
+            args = self.parser.parse_args()
+            self._validate_args(args)
+            
+            if args.verbose:
+                print(f"Starting substitution simulation with {args.algorithm} algorithm...")
+                print(f"Tree file: {args.tree_file}")
+                print(f"Number of simulations: {args.number_of_simulations}")
+                print(f"Output directory: {args.output_directory}")
+            
+            # Run simulations
+            results = []
+            total_start_time = time.perf_counter()
+            
+            for i in range(args.number_of_simulations):
+                result = self._run_single_simulation(args, i)
+                results.append(result)
+            
+            total_end_time = time.perf_counter()
+            
+            # Save results
+            self._save_results(results, args)
+            
+            # Print benchmark results if requested
+            if args.benchmark or args.verbose:
+                self._print_benchmark_results(results, args)
+            
+            if args.verbose:
+                print(f"\nAll simulations completed in {total_end_time - total_start_time:.3f}s")
+                print(f"Results saved to: {args.output_directory}")
+        
+        except Exception as e:
+            print(f"Error: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    def run_sub(self) -> None:
+        """New"""
+        
+
+
+def main():
+    """Main function."""
+    simulator = SubstitutionSimulatorCLI()
+    simulator.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add a substitution-only simulator. 
The simulator models amino acid substitutions along a phylogenetic tree using the JTT model and operates independently of the existing indel simulation logic.